### PR TITLE
Remediate ansible documentation authority audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ changelogs/.plugin-cache.yaml
 CLAUDE.md
 AGENTS.md
 SECURITY.md
+strict-audit
 
 # Local bootstrapping scripts (not for adopters)
 scripts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Startup
+
+This repository operates under the platform contract.
+
+Read first:
+
+../platform-docs/_platform/PLATFORM_OPERATING_MODEL.md
+../platform-docs/_platform/REPO_TAXONOMY.md
+../platform-docs/_platform/ARCHITECTURAL_DOCTRINE_TIER0.md
+../platform-docs/_platform/CONTRACT_SCHEMA.md
+../platform-docs/_platform/CONTRACT_VALIDATION.md
+../platform-docs/_platform/LIFECYCLE_MODEL.md
+../platform-docs/_platform/GENERATOR_MODEL.md
+../platform-docs/_platform/PR_WORKFLOW.md
+
+Authority constraints:
+
+- No kubectl access.
+- Any kubectl steps must be labeled: **Run manually by human**.
+
+Before editing, classify repo scope using `REPO_TAXONOMY.md` and determine whether changes are single-repo or cross-repo.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Ansible repository for managing infrastructure across multiple environments, running in Docker for consistency and portability.
 
+Repository Category: `infrastructure` (see `platform-docs/_platform/REPO_TAXONOMY.md`)
+
+Documentation authority boundary:
+- This repository documents implementation and operations for Ansible-managed infrastructure behavior.
+- Platform governance, lifecycle, and contract doctrine remain authoritative in `platform-docs/_platform/`.
+
 ## Current Setup
 
 ### k3s Cluster Management


### PR DESCRIPTION
## Summary
- add `AGENTS.md` and align agent startup references to current platform contract docs
- add explicit repository category to README
- clarify docs authority boundary (implementation docs local, governance in `platform-docs/_platform/`)
- ignore local `strict-audit` artifact in `.gitignore`

## Testing
- docs-only changes; no runtime tests required